### PR TITLE
Update TerrariaChatRelay to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [Crossplay](https://github.com/Moneylover3246/Crossplay) by Moneylover3246
   * Provides support for mobile and other older-versioned players to join terraria servers on the newer versions.
   * Tested on TShock 4.5.6.
-  * [Download v1.6.0](https://files.catbox.moe/ltz8wl.dll)
+  * [Download v1.6.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Crossplay/Crossplay-1.6.0.dll)
   * [Documentation](https://github.com/Moneylover3246/Crossplay/blob/main/README.md)
   * [Source code](https://github.com/Moneylover3246/Crossplay/)
 * AdvancedWarpplates

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [TemplateMOTDPlugin](https://github.com/Arthri/TemplateMOTDPlugin) by Arthri
   * TemplateMOTDPlugin replaces TShock's MOTD engine with [Scriban](https://github.com/scriban/scriban).
   * Tested on TShock 4.5.5
-  * [Download Version 1.0.0](https://files.catbox.moe/73sl3l.zip)
+  * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/TemplateMOTDPlugin/TemplateMOTDPlugin-1.0.0.zip)
   * [Documentation](https://github.com/Arthri/TemplateMOTDPlugin)
   * [Source code](https://github.com/Arthri/TemplateMOTDPlugin)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [IRCrarria](https://github.com/lemon-sh/IRCrarria) by lemon-sh
   * A very simple IRC<->Terraria chat bridge.
   * Tested on TShock 4.5.5.
-  * [Download Version 1.2.0](https://files.catbox.moe/70d6vl.zip)
+  * [Download Version 1.2.0](https://argo.sfo2.digitaloceanspaces.com/tshock/IRCRarria/IRCrarria-1.2.0.zip)
   * [Source code](https://github.com/lemon-sh/IRCrarria)
 * [MultiSCore](https://github.com/Megghy/MultiSCore/releases/) by Megghy
   * An easy-to-use Terraria multi-world plugin that allows you to teleport directly to other servers in-game and back via a proxy

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [Crossplay](https://github.com/Moneylover3246/Crossplay) by Moneylover3246
   * Provides support for mobile and other older-versioned players to join terraria servers on the newer versions.
   * Tested on TShock 4.5.5.
-  * [Download v1.5.0](https://files.catbox.moe/1aptgb.dll)
+  * [Download v1.5.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Crossplay/Crossplay-1.5.0.dll)
   * [Documentation](https://github.com/Moneylover3246/Crossplay/blob/main/README.md)
   * [Source code](https://github.com/Moneylover3246/Crossplay/)
 * AdvancedWarpplates

--- a/README.md
+++ b/README.md
@@ -13,51 +13,51 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [AutoTeam](https://github.com/TerraTrapezium/AutoTeam) by [Metacinnabar](https://github.com/Metacinnabar)
   * Automatically assigns players a configurable team on world join.
   * Tested on TShock 4.5.5
-  * [Download Version 1.0.0](https://files.catbox.moe/14tcj8.dll) (`AutoTeam.dll`)
+  * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/AutoTeam/AutoTeam-1.0.0.dll) (`AutoTeam.dll`)
   * [Source code](https://github.com/TerraTrapezium/AutoTeam)
 * [ChatManager](https://github.com/Rozen4334/ChatManager/releases/tag/v1.1) by Rozen4334
   * A chat & username checker plugin that offers lots of configuration & lots of features.
   * Tested on TShock 4.5.5.
   * NOTE: Please remove NameValidator as this replaces & upgrades that plugin.
-  * [Download](https://files.catbox.moe/wt27p8.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/ChatManager/ChatManager-1.1.zip)
   * [Source code](https://github.com/Rozen4334/ChatManager)
 * [IRCrarria](https://github.com/lemon-sh/IRCrarria) by lemon-sh
   * A very simple IRC<->Terraria chat bridge.
   * Tested on TShock 4.5.5.
-  * [Download Version 1.0.0](https://files.catbox.moe/9sufi0.zip)
+  * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/IRCRarria/IRCrarria-1.0.0.zip)
   * [Source code](https://github.com/lemon-sh/IRCrarria)
 * [MultiSCore](https://github.com/Megghy/MultiSCore/releases/) by Megghy
   * An easy-to-use Terraria multi-world plugin that allows you to teleport directly to other servers in-game and back via a proxy
   * You can adjust the plugin language in the configuration file or modify it to your preferred sentence
   * Tested on TShock 4.5.5
-  * [Download Version 1.5.2](https://files.catbox.moe/h1plqy.dll)
+  * [Download Version 1.5.2](https://argo.sfo2.digitaloceanspaces.com/tshock/MultiScore/MultiScore-1.5.2.dll)
   * [Documentation](https://www.bbstr.net/r/75/)
   * [Source code](https://github.com/Megghy/MultiSCore/)
 * [TerrariaChatRelay](https://github.com/xPanini/TCR-TerrariaChatRelay-TShock) by [Lady Narnia (xPanini)](https://github.com/xPanini)
   * Highly customizable Terraria Chat Relay with multiple Discord server support
   * Tested on TShock 4.5.5.
-  * [Download Version 0.9.2](https://files.catbox.moe/avy37t.zip)
+  * [Download Version 0.9.2](https://argo.sfo2.digitaloceanspaces.com/tshock/TerrariaChatRelay/TerrariaChatRelay-0.9.2.zip)
   * [Documentation](https://github.com/xPanini/TCR-TerrariaChatRelay/wiki)
   * [Source code](https://github.com/xPanini/TCR-TerrariaChatRelay-TShock)
 * [WorldMapper](https://github.com/drunderscore/WorldMapper) by Dr. Underscore
   * Allows generation of a PNG map of the entire world.
   * Tested on TShock 4.5.2
-  * [Download](https://files.catbox.moe/7qfpmf.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/WorldMapper/WorldMapper-1.0.0.zip)
   * [Source code](https://github.com/drunderscore/WorldMapper)
 * [TPAccept](https://github.com/Rozen4334/TPAccept/releases/tag/1.0) by Rozen4334 & nyan-ko
   * A replacement for the base TP feature, inspired by Minecrafts '/tpa'
   * Tested on TShock 4.5.2
-  * [Download](https://files.catbox.moe/8d5oyp.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/TPAccept/TPAccept-1.0.dll)
   * [Source code](https://github.com/Rozen4334/TPAccept)
 * [Buildmode](https://github.com/Rozen4334/Buildmode/releases/tag/v1.2) by nyan-ko & Rozen4334
   * Allows players to enter a permaday state without cave backgrounds, adds buffs & more!
   * Tested on TShock 4.5.2
-  * [Download](https://files.catbox.moe/3ukc93.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/Buildmode/Buildmode-1.2.dll)
   * [Source code](https://github.com/Rozen4334/Buildmode)
 * [MapTP](https://github.com/Rozen4334/MapTP/releases/tag/v1.0) by Rozen4334
   * Allows players to teleport to any location on the map, by simply double clicking said location!
   * Tested on TShock 4.5.2
-  * [Download](https://files.catbox.moe/8cdd3x.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/MapTP/MapTP-1.0.dll)
   * [Source code](https://github.com/Rozen4334/MapTP)
 * [AdditionalPylons](https://github.com/Adventure-Terraria-Server-Project/AdditionalPylons-Plugin) by [Stealownz](https://github.com/Stealownz)
   * Allows placing additional (infinite) pylons more than default Terraria limits
@@ -68,146 +68,146 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
   * Allows journey mode characters to join a non journey mode world and now visa versa.
   * Tested on prerelease 15.
   * Source https://github.com/Rustly/JourneyMixer
-  * Download https://files.catbox.moe/d9r1jr.dll
+  * Download https://argo.sfo2.digitaloceanspaces.com/tshock/JourneyMixer/JourneyMixer.dll
 * InfiniteChestsV3 by Zaicon
   * Allows "infinite" chests and additional features such as auto-refill, password-protected chests, and more.
   * Tested on TShock 4.4.0 Pre-2.
-  * [Download Version 1.3.0.0](https://files.catbox.moe/qqdffp.dll)
+  * [Download Version 1.3.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/InfiniteChestsV3/InfiniteChests-1.3.0.0.dll)
   * [Documentation](https://github.com/Zaicon/InfiniteChestsV3)
   * [Source code](https://github.com/Zaicon/InfiniteChestsV3)
 * ZAdminCmds
   * Zaicon's ZAdminCmds updated to 1.4. (https://github.com/Zaicon/ZAdminCmds)
   * Tested on TShock 4.4.0 Pre-10.
-  * [Download](https://files.catbox.moe/gvqzxu.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/ZAdminCmds/ZAdminCmds.dll)
   * [Source code](https://github.com/Rustly/ZAdminCmds)
 * [Crossplay](https://github.com/Moneylover3246/Crossplay) by Moneylover3246
   * Allows crossplay to happen in terraria servers via packet handling and manipulation
   * Tested on TShock 4.5.5.
-  * [Download v1.4.2.1 - For TShock 4.5.4+](https://files.catbox.moe/vrszug.dll)
-  * [Download v1.1.1 - For TShock 4.4.0 pre-12](https://files.catbox.moe/jaxve6.dll)
+  * [Download v1.4.2.1 - For TShock 4.5.4+](https://argo.sfo2.digitaloceanspaces.com/tshock/Crossplay/Crossplay-1.4.2.1.dll)
+  * [Download v1.1.1 - For TShock 4.4.0 pre-12](https://argo.sfo2.digitaloceanspaces.com/tshock/Crossplay/Crossplay-1.1.1.dll)
   * [Documentation](https://github.com/Moneylover3246/Crossplay/blob/main/README.md)
   * [Source code](https://github.com/Moneylover3246/Crossplay/)
 * AdvancedWarpplates
   * Rofle's AdvancedWarpplates but actually including a build in the repo. (https://github.com/popstarfreas/AdvancedWarpplates)
   * Tested on TShock 4.4.0 Pre-10.
-  * [Download](https://files.catbox.moe/5evaiv.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/AdvancedWarpplates/AdvancedWarpplates.dll)
   * [Source code](https://github.com/Rustly/AdvancedWarpplates)
 * ShortCommands
   * Zaicon's ShortCommands updated to 1.4. (https://github.com/Zaicon/ShortCommands)
   * Tested on TShock 4.4.0 Pre-10.
-  * [Download](https://files.catbox.moe/3wdlk7.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/ShortCommands/ShortCommands.dll)
   * [Source code](https://github.com/Rustly/ShortCommands)
 * CloneNotify
   * Zaicon's CloneNotify updated to 1.4. (https://github.com/Zaicon/CloneNotify)
   * Tested on TShock 4.4.0 Pre-10.
-  * [Download](https://files.catbox.moe/sqq56g.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/CloneNotify/CloneNotify.dll)
   * [Source code](https://github.com/Rustly/CloneNotify)
 * CustomMediumcore by Miffyli
   * Ease Mediumcore by selecting which items are dropped upon death.
   * Requirements: Server-side characters enabled. Players must have "Casual" difficulty.
   * Place `drop_item_ids.txt` next to `TerrariaServer.exe`.
   * Tested on TShock 4.4.0 Pre-3.
-  * [Download Version 1.4.0.1](https://files.catbox.moe/2tplf7.zip)
+  * [Download Version 1.4.0.1](https://argo.sfo2.digitaloceanspaces.com/tshock/CustomMediumcore/CustomMediumcore-1.4.0.1.zip)
   * [Source code and documentation](https://github.com/Miffyli/TerrariaCustomMediumcore)
 * Tiled by thanatos-tshock
   * Provides alternate tile implementations which improve performance and memory usage
   * Tested on TShock 4.4.0 Pre-3.
-  * [Download Version 1.4.0.0](https://files.catbox.moe/qmcthi.dll)
+  * [Download Version 1.4.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Tiled/Tiled-1.4.0.0.dll)
   * [Source code](https://github.com/thanatos-tshock/Tiled)
 * FACommands by MineBartekSA
   * Originally created by Hiarni & Zaicon
   * Fun and Admin Commands
   * Tested on TShock 4.4.0 Pre-12.
-  * [Download Version 1.7.1](https://files.catbox.moe/elsv0g.dll)
+  * [Download Version 1.7.1](https://argo.sfo2.digitaloceanspaces.com/tshock/FACommands/FACommands-1.7.1.dll)
   * [Source code](https://github.com/MineBartekSA/FACommands)
 * [Terracord](https://github.com/FragLand/terracord) by [ldilley](https://github.com/ldilley)
   * A Discord <-> Terraria bridge plugin for TShock
   * Tested on TShock 4.5.5.
-  * [Download Version 1.3.1](https://files.catbox.moe/u9wrwm.zip)
+  * [Download Version 1.3.1](https://argo.sfo2.digitaloceanspaces.com/tshock/Terracord/TerraCord-1.3.1.zip)
   * [Documentation](https://github.com/FragLand/terracord/blob/master/.github/README.md)
   * [Source code](https://github.com/FragLand/terracord)
 * TerraJump by MineBartekSA
   * Simple plugin that adds JumpPads
   * Tested on TShock 4.4.0 Pre-15.
-  * [Download Version 2.3.1](https://files.catbox.moe/oc1a1a.dll)
+  * [Download Version 2.3.1](https://argo.sfo2.digitaloceanspaces.com/tshock/TerraJump/TerraJump-2.3.1.dll)
   * [Source code](https://github.com/MineBartekSA/TerraJump)
 * [Invincible Tiles (and walls)](https://github.com/Olink/Invincible-Tiles) by Olink
   * Adds the ability for players to blacklist tile ids and wall ids, preventing users from breaking said tiles/walls.
   * Tested on TShock 4.4.0 Pre-6.
-  * [Download Version 1.0](https://files.catbox.moe/35914m.dll)
+  * [Download Version 1.0](https://argo.sfo2.digitaloceanspaces.com/tshock/InvincibleTiles/InvincibleTiles-1.0.0.dll)
   * [Source code](https://github.com/Olink/Invincible-Tiles)
 * [TServerWeb - Online Server Manager for TShock](https://www.tserverweb.com/) by XGhozt
   * Manage your TShock server from the web, run commands, manage players, groups, permissions and more.
   * Tested on TShock 4.4.0 Pre-7.
-  * Addon: [TServerWeb In-Game Vote Plugin](https://gitlab.xghozt.com:2345/tsw/TSWVote/raw/master/Build/TSWVote.dll) / [Source Code](https://gitlab.xghozt.com:2345/tsw/TSWVote)
-  * Addon: [TServerWeb Remote Console](https://gitlab.xghozt.com:2345/tsw/tswconsole/raw/master/Build/TSWConsole.dll) / [Source Code](https://gitlab.xghozt.com:2345/tsw/tswconsole)
+  * Addon: [TServerWeb In-Game Vote Plugin](https://argo.sfo2.digitaloceanspaces.com/tshock/TServerWeb/TSWVote.dll) / [Source Code](https://gitlab.xghozt.com:2345/tsw/TSWVote)
+  * Addon: [TServerWeb Remote Console](https://argo.sfo2.digitaloceanspaces.com/tshock/TServerWeb/TSWConsole.dll) / [Source Code](https://gitlab.xghozt.com:2345/tsw/tswconsole)
   * [Discord Server](https://discord.gg/s63fqsW)
 * Vanillafier
   * Sets up your server to run like the vanilla Terraria server in 1 easy command
   * Built on TShock 4.5.0
-  * [Download](https://files.catbox.moe/cy8sca.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/Vanillafier/Vanillafier-1.0.0.zip)
   * [Source Code](https://github.com/Pryaxis/Vanillafier)
 * [Creative Mode](https://tshock.co/xf/index.php?resources/creative-mode.19/) by Bippity
   * A simple "Creative Mode" for players
   * Built on TShock 4.4.0 Pre-8
-  * [Download](https://files.catbox.moe/tkfyvq.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/CreativeMode/CreativeMode.dll)
   * [Documentation/Source Code](https://github.com/bippity/CreativeMode)
 * [TDiffBackup](https://github.com/tieonlinux/TDiffBackup) by [tieonlinux](https://github.com/tieonlinux)
   * World file backup system
   * Built on TShock 4.4.0 Pre-11
-  * [Download](https://files.catbox.moe/f8axjx.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/TDiffBackup/TDiffBackup.zip)
   * [Documentation/Source Code](https://github.com/tieonlinux/TDiffBackup)
 * [ShortCommands](https://github.com/tieonlinux/ShortCommands) by [Zaicon](https://github.com/Zaicon), updated by [tieonlinux](https://github.com/tieonlinux)
   * Create commands aliases/shortcuts
   * Built and tested on TShock 4.4.0 Pre-11.
-  * [Download](https://files.catbox.moe/isj2rw.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/ShortCommands/fork/ShortCommands-tieonlinux-fork.zip)
   * [Documentation/Source Code](https://github.com/tieonlinux/ShortCommands)
 * [Team Commands](https://github.com/ZakFahey/Team-Commands) by GameRoom
   * Run commands for a whole team.
   * Built on TShock 4.4.0 Pre-8
-  * [Download Version 1.2](https://files.catbox.moe/8mlw7v.dll)
+  * [Download Version 1.2](https://argo.sfo2.digitaloceanspaces.com/tshock/TeamCommands/TeamCommands-1.2.dll)
   * [Documentation](https://github.com/ZakFahey/Team-Commands/blob/master/README.md)
   * [Source code](https://github.com/ZakFahey/Team-Commands)
 * [Smart Regions](https://github.com/ZakFahey/SmartRegions) by GameRoom
   * Run programmable commands when a player is in a region.
   * Compatible with TShock 4.5.x
-  * [Download Version 1.3.1](https://files.catbox.moe/pusl50.dll)
+  * [Download Version 1.3.1](https://argo.sfo2.digitaloceanspaces.com/tshock/SmartRegions/SmartRegions-1.3.1.dll)
   * [Documentation](https://github.com/ZakFahey/SmartRegions/blob/master/README.md)
   * [Source code](https://github.com/ZakFahey/SmartRegions)
 * [Normal Boss Bags](https://github.com/Quinci135/NormalBossBags) by Quinci
   * Makes normal mode bosses drop treasure bags as if it were expert mode
   * Built and tested on TShock 4.4.0 Pre-12
-  * [Download Version 1.0](https://files.catbox.moe/647789.zip)
+  * [Download Version 1.0](https://argo.sfo2.digitaloceanspaces.com/tshock/NormalBossBags/NormalBossBags-1.0.zip)
   * [Source code](https://github.com/Quinci135/NormalBossBags)
 * [AFK Warp/Kick Plugin](https://tshock.co/xf/index.php?resources/afk-warp-kick.104/) by Bippity
   * Idle players will be warped/kicked after a defined time
   * Built on TShock 4.4.0 Pre-12
-  * [Download Version 1.1](https://files.catbox.moe/bmm85t.zip)
+  * [Download Version 1.1](https://argo.sfo2.digitaloceanspaces.com/tshock/AFKWarp/AFKWarp-1.1.zip)
   * [Documentation/Source Code](https://github.com/bippity/AFK)
 * [Buff Emoticons](https://github.com/Dylanswaggerino/Buff-Emotions) by The Killer [NL]
   * Gives the user a in-game buff for 46 seconds!
   * Tested on TShock 4.4.0 Pre-15.
-  * [Download Version 2.1](https://files.catbox.moe/ta8nc9.dll)
+  * [Download Version 2.1](https://argo.sfo2.digitaloceanspaces.com/tshock/BuffEmoticons/BuffEmoticons-2.1.dll)
   * [Documentation](https://github.com/Dylanswaggerino/Buff-Emotions/blob/master/README.md)
   * [Source code](https://github.com/Dylanswaggerino/Buff-Emotions)
 * [ListPluginsPlugin](https://github.com/Arthri/ListPluginsPlugin) by Arthri
   * Provides commands for listing the currently loaded plugins.
   * Tested on TShock 4.5.5
-  * [Download Version 1.0.1](https://files.catbox.moe/yqgpwt.dll)
+  * [Download Version 1.0.1](https://argo.sfo2.digitaloceanspaces.com/tshock/ListPluginsPlugin/ListPluginsPlugin-1.0.dll)
   * [Documentation](https://github.com/Arthri/ListPluginsPlugin#listpluginsplugin)
   * [Source code](https://github.com/Arthri/ListPluginsPlugin)
-  
-### Community Maintained Plugins 
+
+### Community Maintained Plugins
 * [WorldEdit](https://github.com/Rozen4334/WorldEdit/releases/tag/v4.5.5) by Nyx Studios & Anzhelika, maintained by Rozen4334.
   * Massive grand-scheme tile edits across the entire map, now with documentation!
   * Tested on TShock 4.5.5.
-  * [Download](https://files.catbox.moe/upwhtl.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/WorldEdit/WorldEdit.dll)
   * [Documentation](https://rozen.one/worldedit.html)
   * [Source code](https://github.com/Rozen4334/WorldEdit)
 * [RegionVision](https://github.com/Rozen4334/RegionVision/releases/tag/1.3) by [Andrio Celos](https://github.com/AndrioCelos), updated and rebranded by Rozen4334
   * Shows region borders to users, by specifying a region or by triggering it for the entire world.
   * Tested on TShock 4.5.2, built on TShock 4.4.0.
-  * [Download](https://files.catbox.moe/1bmlkz.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/RegionVision/RegionVision.dll)
   * [Source code](https://github.com/Rozen4334/RegionVision)
 * [AutoRegister](https://github.com/moisterrific/TShockAutoRegister) by [brian91292](https://github.com/brian91292), updated by [moisterrific](https://github.com/moisterrific)
   * Temporarily removed due to a secure code review failure. A defect in the design by @brian91292 would lead to generating predictable passwords that could be easily obtained by malicious servers.
@@ -219,71 +219,72 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
   * [Documentation](https://github.com/moisterrific/NPCBlocker2/blob/main/README.md)
   * [Source Code](https://github.com/moisterrific/NPCBlocker2/blob/main/NPCBlocker/NPCBlocker.cs)
 * [Character Reset (SSC)](https://github.com/bippity/CharacterReset) by [Bippity](https://github.com/bippity), updated by [moisterrific](https://github.com/moisterrific)
-  * Allows you to reset SSC player data without the hassle of database editing. 
+  * Allows you to reset SSC player data without the hassle of database editing.
   * Built and tested on TShock 4.5.2.0 (April Lyrids edition).
-  * [Download Version 1.0.3](https://files.catbox.moe/seefnu.zip)
+  * [Download Version 1.0.3](https://argo.sfo2.digitaloceanspaces.com/tshock/ResetSSC/ResetSSC-1.0.3.zip)
   * [Documentation](https://github.com/moisterrific/CharacterReset/blob/master/README.md)
   * [Source Code](https://github.com/moisterrific/CharacterReset/blob/master/CharacterReset.cs)
 * [Ghost](https://github.com/DannyDan77/Ghost) by [DannyDan77](https://github.com/DannyDan77), updated by [moisterrific](https://github.com/moisterrific)
   * Allows admins to become invisible to other players.
   * Built and tested on TShock 4.4.0 Pre-11.
-  * [Download Version 1.2.0](https://files.catbox.moe/rh3myj.zip)
+  * [Download Version 1.2.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Ghost/Ghost-1.2.0.zip)
   * [Documentation (pls read!)](https://github.com/moisterrific/Ghost/blob/master/README.md)
   * [Source Code](https://github.com/moisterrific/Ghost/blob/master/GhostPlugin/GhostPlugin.cs)
 * [InfiniteChestsV3](https://github.com/Zaicon/InfiniteChestsV3) by [Zaicon](https://github.com/Zaicon), updated by [moisterrific](https://github.com/moisterrific)
   * Allows "infinite" chests and additional features such as auto-refill, password-protected chests, and more.
   * Built and tested on TShock 4.5.2.0 (April Lyrids edition).
-  * [Download Version 1.2.1](https://files.catbox.moe/5zjurx.zip)
+  * [Download Version 1.2.1](https://argo.sfo2.digitaloceanspaces.com/tshock/InfiniteChests/InfiniteChests-1.2.1.zip)
   * [Documentation](https://github.com/moisterrific/InfiniteChestsV3/blob/master/README.md)
   * [Source Code](https://github.com/moisterrific/InfiniteChestsV3/tree/master/InfiniteChestsV3)
+
 #### Compatible with older TShock versions
 * [Calculator](https://github.com/edg-l/Calculator) by [edg-l](https://github.com/edg-l)
   * A calculator plugin.
   * Built on TShock 4.4.0 Pre-11.
-  * [Download 1.0.0.0](https://files.catbox.moe/nkieg4.zip)
+  * [Download 1.0.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Calculator/Calculator-1.0.0.0.zip)
   * [Source code](https://github.com/edg-l/Calculator)
 * [PlayerInfo](https://github.com/Brycey92/PlayerInfo/tree/terraria-1.4) by [ParadonX](https://github.com/ParadonX), updated by [Brycey92](https://github.com/Brycey92)
   * A player info modifier/checker.
   * Built on TShock 4.4.0 Pre-11.
-  * [Download 1.8](https://files.catbox.moe/fwqfl5.zip)
+  * [Download 1.8](https://argo.sfo2.digitaloceanspaces.com/tshock/PlayerInfo/PlayerInfo-1.8.zip)
   * [Source code](https://github.com/Brycey92/PlayerInfo/tree/terraria-1.4)
 * [SummonLimit](https://github.com/moisterrific/SummonLimit) by [Newy](https://github.com/newyrose), updated by [moisterrific](https://github.com/moisterrific)
   * Prevents summon hacking.
   * Built on TShock 4.4.0 Pre-11.
-  * [Download](https://files.catbox.moe/mr52x7.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/SummonLimit/SummonLimit.zip)
   * [Source code](https://github.com/moisterrific/SummonLimit)
 * [TshockLogs_Explosives](https://github.com/moisterrific/TshockLogs_Explosives) by [slzn](https://github.com/slzn), updated by [moisterrific](https://github.com/moisterrific)
   * Helps to track explosives(Bomb, Dynamite, etc... ) usage.
   * Built on TShock 4.4.0 Pre-11.
-  * [Download](https://files.catbox.moe/flnmuh.zip)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/TShockLogs_Explosives/TShockLogs_Explosives.zip)
   * [Documentation](https://github.com/moisterrific/TshockLogs_Explosives#config)
   * [Source code](https://github.com/slzn/TshockLogs_Explosives)
 * [WorldEdit](https://github.com/Brycey92/WorldEdit)
   * Adds mass tile editing commands.
   * Built on TShock 4.4.0 Pre-11.
-  * [Download 1.8.0](https://files.catbox.moe/2h14dl.zip)
+  * [Download 1.8.0](https://argo.sfo2.digitaloceanspaces.com/tshock/WorldEdit/fork/WorldEdit.zip)
   * [Source code](https://github.com/Brycey92/WorldEdit)
 * [RodHealer](https://github.com/ancientgods/RodHealer) by [ancientgods](https://github.com/ancientgods), updated by [moisterrific](https://github.com/moisterrific)
   * Prevents players from losing HP when spamming the Rod of Discord.
   * Built and tested on TShock 4.4.0 Pre-11.
-  * [Download Version 1.2.0](https://files.catbox.moe/gocgdm.zip)
+  * [Download Version 1.2.0](https://argo.sfo2.digitaloceanspaces.com/tshock/RodHealer/RodHealer-1.2.0.zip)
   * [Documentation](https://github.com/moisterrific/RodHealer/blob/master/README.md)
   * [Source Code](https://github.com/moisterrific/RodHealer/blob/master/Rodhealer/main.cs)
 * [World Refill](https://github.com/k0rd/WorldRefill) by [K0rd](https://github.com/k0rd), updated by [Illuminousity](https://github.com/Illuminousity)
   * Refill your world with structures and resources!
   * Built and tested on Tshock 4.4.0 Pre-11.
-  * [Download Version 2.1.3](https://files.catbox.moe/3fdrrv.zip)
+  * [Download Version 2.1.3](https://argo.sfo2.digitaloceanspaces.com/tshock/WorldRefill/WorldRefill.zip)
   * [Documentation](https://github.com/Illuminousity/WorldRefill/blob/master/README.md)
   * [Source Code](https://github.com/Illuminousity/WorldRefill)
 * [Auto Team](https://github.com/dredhorse/tShockAutoTeam) by Don Redhorse
    * Joins the players to a team based on permissions
    * Tested on TShock 4.4.0 Pre-12.
-   * [Download Version 1.0.0](https://files.catbox.moe/1ouznb.dll)
+   * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/AutoTeam/fork/AutoTeam-1.0.0.dll)
    * [Documentation and SourceCode](https://github.com/dredhorse/tShockAutoTeam)
 * [TShockPrometheus](https://github.com/swantzter/tshock-prometheus) by [Swantzter](https://github.com/swantzter)
   * Exposes the current player count on the server to prometheus
   * Tested on TShock 4.4.0 Pre-15.
-  * [Download Version 1.0.0](https://files.catbox.moe/lfi2sm.zip)
+  * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/TShockPrometheus/TShockPrometheus-1.0.0.zip)
   * [Source code](https://github.com/swantzter/tshock-prometheus)
 * [TShock Server REST Mobile](https://github.com/KohlsAdrian/tshock_server_rest) by [647](https://github.com/KohlsAdrian)
   * Manage players/users, bans, world, groups and server directly from your mobile device.
@@ -294,20 +295,20 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [Essentials+](https://github.com/QuiCM/EssentialsPlus) by [QuiCM](https://github.com/QuiCM) (and various others <3)
   * Compatible with TShock v4.5.x
   * Numerous 'essential' tools for enhancing gameplay & administration capabilities
-  * [Download](https://files.catbox.moe/2z23s9.dll)
+  * [Download](https://argo.sfo2.digitaloceanspaces.com/tshock/EssentialsPlus/EssentialsPlus.dll)
   * [Source](https://github.com/QuiCM/EssentialsPlus)
 ----
 
 ## How to submit plugins
 
 1. Compile your plugin as normal.
-2. Upload your release and any resources you need to [Catbox](https://catbox.moe/). This will be the download link for your plugin.
+2. Upload your release and any resources you need to [Catbox](https://catbox.moe/) or another service. Your plugin will be reuploaded to DigitalOcean Spaces after it has been reviewed, for download. Please provide a link to download your plugin in your pull-request.
 3. Upload the source code to your plugin to GitHub. You do **not** need to make your source a copyleft license (like GPL) or even make it anything other than proprietary.
 4. Copy the template below and add in the required things in the required spots.
 5. Send a pull request to this repository. Add your plugin to the list above near the other plugins.
 6. Don't remove anything that isn't yours and don't change anything you didn't already add.
 7. When your plugin is approved, it will be added to the list.
-8. When you need to update your plugin, change the version number or other attributes, upload to [Catbox](https://catbox.moe/), and then re-submit your plugin.
+8. When you need to update your plugin, change the version number or other attributes, upload to [Catbox](https://catbox.moe/) or another service, and then re-submit your plugin. Your download link will be updated to reflect the new version.
 9. New plugins can appear at the top of the list. You are not guaranteed to be at the top of the list for long. If you comment on whether or not you should or shouldn't be placed at the top of the list, you will be placed not at the top of the list. You are forbidden from 'renaming' a plugin to a different name and resubmitting as a new plugin to appear at the top of the list. If we suspect that you have done this, you will be moved to the bottom of the list.
 
 This is the sample template:
@@ -360,6 +361,7 @@ These are the changes made to this page that aren't really plugin related.
 3. Add slow plugin review scheme. - June 18, 2020.
 4. Plugin slowness scheme revised to require one plugin per PR to be elligable. - May 28, 2021
 5. Clarified review process, added tips for making reviws faster. - Aug 11, 2021
+6. Uploaded all plugins to DigitalOcean Spaces so that plugins can be deleted serverside if necessary. - October 17, 2021
 
 ### Final note
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [Crossplay](https://github.com/Moneylover3246/Crossplay) by Moneylover3246
   * Provides support for mobile and other older-versioned players to join terraria servers on the newer versions.
   * Tested on TShock 4.5.9.
-  * [Download v1.7.0](https://files.catbox.moe/lh8vef.dll)
+  * [Download v1.7.0](https://argo.sfo2.digitaloceanspaces.com/tshock/Crossplay/Crossplay-1.7.0.dll)
   * [Documentation](https://github.com/Moneylover3246/Crossplay/blob/main/README.md)
   * [Source code](https://github.com/Moneylover3246/Crossplay/)
 * AdvancedWarpplates

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
   * [Download Version 1.5.4](https://argo.sfo2.digitaloceanspaces.com/tshock/MultiScore/MultiSCore-1.5.4.dll)
   * [Documentation](https://www.bbstr.net/r/75/)
   * [Source code](https://github.com/Megghy/MultiSCore/)
-* [TerrariaChatRelay](https://github.com/xPanini/TCR-TerrariaChatRelay-TShock) by [Lady Narnia (xPanini)](https://github.com/xPanini)
+* [TerrariaChatRelay](https://github.com/xNarnia/TCR-TerrariaChatRelay) by [Narnia (Panini)](https://github.com/xNarnia)
   * Highly customizable Terraria Chat Relay with multiple Discord server support
-  * Tested on TShock 4.5.5.
-  * [Download Version 1.0.0 for TShock 4.5.5](https://files.catbox.moe/38gm3q.zip)
+  * Tested on TShock 5.2.1.
+  * [Download Version 2.3.0.1 for TShock 5.2.1](https://files.catbox.moe/mjrdvn.zip)
   * [Download Version 1.0.0 for TShock 4.4.0-pre12](https://files.catbox.moe/d9mpej.zip)
-  * [Documentation](https://github.com/xPanini/TCR-TerrariaChatRelay/wiki)
-  * [Source code](https://github.com/xPanini/TCR-TerrariaChatRelay-TShock)
+  * [Documentation](https://github.com/xNarnia/TCR-TerrariaChatRelay/wiki)
+  * [Source code](https://github.com/xNarnia/TCR-TerrariaChatRelay)
 * [WorldMapper](https://github.com/drunderscore/WorldMapper) by Dr. Underscore
   * Allows generation of a PNG map of the entire world.
   * Tested on TShock 4.5.2


### PR DESCRIPTION
I had forgotten to update the AssemblyInfo from 0.9.2 to 1.0.0 last time... 
So I updated the plugin to 1.0.0 instead!.... Just kidding!

This is an actual v1.0.0 release with a ton of changes. 
The AssemblyInfo has been updated to reflect the version.

Thank you!