### PR TITLE
Update IRCrarria to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
 * [IRCrarria](https://github.com/lemon-sh/IRCrarria) by lemon-sh
   * A very simple IRC<->Terraria chat bridge.
   * Tested on TShock 4.5.5.
-  * [Download Version 1.0.0](https://argo.sfo2.digitaloceanspaces.com/tshock/IRCRarria/IRCrarria-1.0.0.zip)
+  * [Download Version 1.2.0](https://files.catbox.moe/70d6vl.zip)
   * [Source code](https://github.com/lemon-sh/IRCrarria)
 * [MultiSCore](https://github.com/Megghy/MultiSCore/releases/) by Megghy
   * An easy-to-use Terraria multi-world plugin that allows you to teleport directly to other servers in-game and back via a proxy


### PR DESCRIPTION
Hey, I'd like to update my plugin, IRCrarria to version 1.2.0.
I am confused about the DigitalOcean Spaces link scheme, so I just added the [Catbox link](https://files.catbox.moe/70d6vl.zip).
FYI, one dependency from the previous version, IrcDotNet has been removed completely. It should be missing.