### PR TITLE
TerraJump 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
   * [Source code](https://github.com/FragLand/terracord)
 * TerraJump by MineBartekSA
   * Simple plugin that adds JumpPads
-  * Tested on TShock 4.4.0 Pre-15.
-  * [Download Version 2.3.1](https://argo.sfo2.digitaloceanspaces.com/tshock/TerraJump/TerraJump-2.3.1.dll)
+  * Tested on TShock 5.1.3.
+  * [Download Version 2.4.0](https://github.com/MineBartekSA/TerraJump/releases/download/v2.4.0/TerraJump.dll)
   * [Source code](https://github.com/MineBartekSA/TerraJump)
 * [Invincible Tiles (and walls)](https://github.com/Olink/Invincible-Tiles) by Olink
   * Adds the ability for players to blacklist tile ids and wall ids, preventing users from breaking said tiles/walls.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This is the TShock plugin repository. All plugins from catbox have been analyzed
   * [Download Version 1.3.1](https://argo.sfo2.digitaloceanspaces.com/tshock/Terracord/TerraCord-1.3.1.zip)
   * [Documentation](https://github.com/FragLand/terracord/blob/master/.github/README.md)
   * [Source code](https://github.com/FragLand/terracord)
-* TerraJump by MineBartekSA
+* [TerraJump](https://github.com/MineBartekSA/TerraJump) by MineBartekSA
   * Simple plugin that adds JumpPads
   * Tested on TShock 5.1.3.
   * [Download Version 2.4.0](https://github.com/MineBartekSA/TerraJump/releases/download/v2.4.0/TerraJump.dll)


### PR DESCRIPTION
Updated plugin to TShock 5.1.3 - Terraria 1.4.4.9.

I have included a download link from the release from the plugin's GitHub repository since the submitting guide permits it.
Although, just under the templates there is a note that mandates Catbox download links which contradicts what the guide allows.
If it is **necessary** for plugins to be submitted with a Catbox download link, please just say so, and I'll properly reupload the update asap.